### PR TITLE
minor fixes to set-dotnet-env scripts

### DIFF
--- a/set-dotnet-env.bash
+++ b/set-dotnet-env.bash
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 asdf_update_dotnet_home() {
   local dotnet_path
   dotnet_path="$(asdf which dotnet)"

--- a/set-dotnet-env.bash
+++ b/set-dotnet-env.bash
@@ -2,7 +2,7 @@
 
 asdf_update_dotnet_home() {
   local dotnet_path
-  dotnet_path="$(asdf which dotnet)"
+  dotnet_path="$(asdf which dotnet 2>/dev/null)"
   if [[ -n "${dotnet_path}" ]]; then
     export DOTNET_ROOT
     DOTNET_ROOT="$(dirname "$(realpath "${dotnet_path}")")"

--- a/set-dotnet-env.fish
+++ b/set-dotnet-env.fish
@@ -1,7 +1,7 @@
 #!/usr/bin/env fish
 
 function asdf_update_dotnet_home --on-event fish_prompt
-    set --local dotnet_path (asdf which dotnet)
+    set --local dotnet_path (asdf which dotnet ^/dev/null)
     if test -n "$dotnet_path"
         set --local full_path (realpath "$dotnet_path")
         set -gx DOTNET_ROOT (dirname "$full_path")

--- a/set-dotnet-env.fish
+++ b/set-dotnet-env.fish
@@ -1,3 +1,5 @@
+#!/usr/bin/env fish
+
 function asdf_update_dotnet_home --on-event fish_prompt
     set --local dotnet_path (asdf which dotnet)
     if test -n "$dotnet_path"

--- a/set-dotnet-env.xsh
+++ b/set-dotnet-env.xsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env xonsh
 
 def asdf_update_dotnet_home() -> None:
-    dotnet_path=$(asdf which dotnet).rstrip('\n')
+    dotnet_path=$(asdf which dotnet 2>/dev/null).rstrip('\n')
     if dotnet_path:
         $DOTNET_ROOT=$(dirname $(realpath @(dotnet_path))).rstrip('\n')
         dotnet_version=$(dotnet --version).rstrip('\n')

--- a/set-dotnet-env.zsh
+++ b/set-dotnet-env.zsh
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+
 asdf_update_dotnet_home() {
   local dotnet_path
   dotnet_path="$(asdf which dotnet)"

--- a/set-dotnet-env.zsh
+++ b/set-dotnet-env.zsh
@@ -2,7 +2,7 @@
 
 asdf_update_dotnet_home() {
   local dotnet_path
-  dotnet_path="$(asdf which dotnet)"
+  dotnet_path="$(asdf which dotnet 2>/dev/null)"
   if [[ -n "${dotnet_path}" ]]; then
     export DOTNET_ROOT
     DOTNET_ROOT="$(dirname "$(realpath "${dotnet_path}")")"


### PR DESCRIPTION
- **fix: add missing shebangs to set-dotnet-env scripts.**
- **fix: redirect stderr of 'asdf which dotnet' in set-dotnet-env scripts**
